### PR TITLE
Displaying headers, body, req, resp and cookies should be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,26 @@ import (
 )
 
 func main() {
-	router := gin.Default()
-	
+    router := gin.Default()
+    
+    showReq := true
+    showResp := true
+    showBody := true
+    showHeaders := false
+    showCookies := false
+    
+    router.Use(gindump.Dump(nil))   // prints on stdout
+    // or
 	router.Use(gindump.Dump(func(dumpStr string) {
 	    fmt.Println(dumpStr)
-	}))
+    }))
+    // or
+    router.Use(gindump.DumpWithOptions(showReq, showResp, showBody, showHeaders, showCookies, nil)   // prints on stdout
+    // or
+	router.Use(gindump.DumpWithOptions(showReq, showResp, showBody, showHeaders, showCookies, func(dumpStr string) {
+	    fmt.Println(dumpStr)
+    }))
+
 	//...
 	router.Run()
 }
@@ -55,7 +70,6 @@ func main() {
 ### Output is as follows
 
 ```sh
-=== RUN   TestMIMEPOSTFORM
 [GIN-dump]:
 Request-Header:
 {
@@ -87,5 +101,4 @@ Response-Body:
     },
     "ok": true
 }
-
 ```

--- a/gindump.go
+++ b/gindump.go
@@ -3,121 +3,141 @@ package gindump
 import (
 	"bytes"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 func Dump(cb func(dumpStr string)) gin.HandlerFunc {
+	return DumpWithOptions(true, true, true, true, true, cb)
+}
+
+func DumpWithOptions(showReq bool, showResp bool, showBody bool, showHeaders bool, showCookies bool, cb func(dumpStr string)) gin.HandlerFunc {
+	headerHiddenFields := []string{}
+	bodyHiddenFields := []string{}
+
+	if showCookies {
+		headerHiddenFields = append(headerHiddenFields, "cookie")
+	}
 
 	return func(ctx *gin.Context) {
-		//dump req header
 		var strB strings.Builder
-		s, err := FormatToJson(ctx.Request.Header)
 
-		if err != nil {
-			strB.WriteString(fmt.Sprintf("\nparse req header err \n" + err.Error()))
-		} else {
-			strB.WriteString("[GIN-dump]:\nRequest-Header:\n")
-			strB.WriteString(string(s))
-		}
+		if showReq && showHeaders {
+			//dump req header
+			s, err := FormatToJson(ctx.Request.Header, headerHiddenFields)
 
-		//dump req body
-		if ctx.Request.ContentLength > 0 {
-			buf, err := ioutil.ReadAll(ctx.Request.Body)
 			if err != nil {
-				strB.WriteString(fmt.Sprintf("\nread bodyCache err \n %s", err.Error()))
-				goto DumpRes
-			}
-			rdr := ioutil.NopCloser(bytes.NewBuffer(buf))
-			ctx.Request.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
-			ctGet := ctx.Request.Header.Get("Content-Type")
-			ct, _, err := mime.ParseMediaType(ctGet)
-			if err != nil {
-				strB.WriteString(fmt.Sprintf("\ncontent_type: %s parse err \n %s", ctGet, err.Error()))
-				goto DumpRes
-			}
-
-			switch ct {
-			case gin.MIMEJSON:
-				bts, err := ioutil.ReadAll(rdr)
-				if err != nil {
-					strB.WriteString(fmt.Sprintf("\nread rdr err \n %s", err.Error()))
-					goto DumpRes
-				}
-
-				s, err := FormatJsonBytes(bts)
-				if err != nil {
-					strB.WriteString(fmt.Sprintf("\nparse req body err \n" + err.Error()))
-					goto DumpRes
-				}
-
-				strB.WriteString("\nRequest-Body:\n")
+				strB.WriteString(fmt.Sprintf("\nparse req header err \n" + err.Error()))
+			} else {
+				strB.WriteString("Request-Header:\n")
 				strB.WriteString(string(s))
-			case gin.MIMEPOSTForm:
-				bts, err := ioutil.ReadAll(rdr)
-				if err != nil {
-					strB.WriteString(fmt.Sprintf("\nread rdr err \n %s", err.Error()))
-					goto DumpRes
-				}
-				val, err := url.ParseQuery(string(bts))
-
-				s, err := FormatToJson(val)
-				if err != nil {
-					strB.WriteString(fmt.Sprintf("\nparse req body err \n" + err.Error()))
-					goto DumpRes
-				}
-				strB.WriteString("\nRequest-Body:\n")
-				strB.WriteString(string(s))
-
-			case gin.MIMEMultipartPOSTForm:
-			default:
 			}
 		}
 
-	DumpRes:
-		ctx.Writer = &bodyWriter{bodyCache: bytes.NewBufferString(""), ResponseWriter: ctx.Writer}
-		ctx.Next()
+		if showReq && showBody {
+			//dump req body
+			if ctx.Request.ContentLength > 0 {
+				buf, err := ioutil.ReadAll(ctx.Request.Body)
+				if err != nil {
+					strB.WriteString(fmt.Sprintf("\nread bodyCache err \n %s", err.Error()))
+					goto DumpRes
+				}
+				rdr := ioutil.NopCloser(bytes.NewBuffer(buf))
+				ctx.Request.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+				ctGet := ctx.Request.Header.Get("Content-Type")
+				ct, _, err := mime.ParseMediaType(ctGet)
+				if err != nil {
+					strB.WriteString(fmt.Sprintf("\ncontent_type: %s parse err \n %s", ctGet, err.Error()))
+					goto DumpRes
+				}
 
-		//dump res header
-		sHeader, err := FormatToJson(ctx.Writer.Header())
-		if err != nil {
-			strB.WriteString(fmt.Sprintf("\nparse res header err \n" + err.Error()))
-		} else {
-			strB.WriteString("\nResponse-Header:\n")
-			strB.WriteString(string(sHeader))
+				switch ct {
+				case gin.MIMEJSON:
+					bts, err := ioutil.ReadAll(rdr)
+					if err != nil {
+						strB.WriteString(fmt.Sprintf("\nread rdr err \n %s", err.Error()))
+						goto DumpRes
+					}
+
+					s, err := FormatJsonBytes(bts, bodyHiddenFields)
+					if err != nil {
+						strB.WriteString(fmt.Sprintf("\nparse req body err \n" + err.Error()))
+						goto DumpRes
+					}
+
+					strB.WriteString("\nRequest-Body:\n")
+					strB.WriteString(string(s))
+				case gin.MIMEPOSTForm:
+					bts, err := ioutil.ReadAll(rdr)
+					if err != nil {
+						strB.WriteString(fmt.Sprintf("\nread rdr err \n %s", err.Error()))
+						goto DumpRes
+					}
+					val, err := url.ParseQuery(string(bts))
+
+					s, err := FormatToJson(val, bodyHiddenFields)
+					if err != nil {
+						strB.WriteString(fmt.Sprintf("\nparse req body err \n" + err.Error()))
+						goto DumpRes
+					}
+					strB.WriteString("\nRequest-Body:\n")
+					strB.WriteString(string(s))
+
+				case gin.MIMEMultipartPOSTForm:
+				default:
+				}
+			}
+
+		DumpRes:
+			ctx.Writer = &bodyWriter{bodyCache: bytes.NewBufferString(""), ResponseWriter: ctx.Writer}
+			ctx.Next()
 		}
 
-		bw, ok := ctx.Writer.(*bodyWriter)
-		if !ok {
-			strB.WriteString("\nbodyWriter was override , can not read bodyCache")
-			goto End
-		}
-
-		//dump res body
-		if bodyAllowedForStatus(ctx.Writer.Status()) && bw.bodyCache.Len() > 0 {
-			ctGet := ctx.Writer.Header().Get("Content-Type")
-			ct, _, err := mime.ParseMediaType(ctGet)
+		if showResp && showHeaders {
+			//dump res header
+			sHeader, err := FormatToJson(ctx.Writer.Header(), headerHiddenFields)
 			if err != nil {
-				strB.WriteString(fmt.Sprintf("\ncontent-type: %s parse  err \n %s", ctGet, err.Error()))
+				strB.WriteString(fmt.Sprintf("\nparse res header err \n" + err.Error()))
+			} else {
+				strB.WriteString("\nResponse-Header:\n")
+				strB.WriteString(string(sHeader))
+			}
+		}
+
+		if showResp && showBody {
+			bw, ok := ctx.Writer.(*bodyWriter)
+			if !ok {
+				strB.WriteString("\nbodyWriter was override , can not read bodyCache")
 				goto End
 			}
-			switch ct {
-			case gin.MIMEJSON:
 
-				s, err := FormatJsonBytes(bw.bodyCache.Bytes())
+			//dump res body
+			if bodyAllowedForStatus(ctx.Writer.Status()) && bw.bodyCache.Len() > 0 {
+				ctGet := ctx.Writer.Header().Get("Content-Type")
+				ct, _, err := mime.ParseMediaType(ctGet)
 				if err != nil {
-					strB.WriteString(fmt.Sprintf("\nparse bodyCache err \n" + err.Error()))
+					strB.WriteString(fmt.Sprintf("\ncontent-type: %s parse  err \n %s", ctGet, err.Error()))
 					goto End
 				}
-				strB.WriteString("\nResponse-Body:\n")
+				switch ct {
+				case gin.MIMEJSON:
 
-				strB.WriteString(string(s))
-			case gin.MIMEHTML:
-			default:
+					s, err := FormatJsonBytes(bw.bodyCache.Bytes(), bodyHiddenFields)
+					if err != nil {
+						strB.WriteString(fmt.Sprintf("\nparse bodyCache err \n" + err.Error()))
+						goto End
+					}
+					strB.WriteString("\nResponse-Body:\n")
+
+					strB.WriteString(string(s))
+				case gin.MIMEHTML:
+				default:
+				}
 			}
 		}
 

--- a/gindump.go
+++ b/gindump.go
@@ -20,7 +20,7 @@ func DumpWithOptions(showReq bool, showResp bool, showBody bool, showHeaders boo
 	headerHiddenFields := []string{}
 	bodyHiddenFields := []string{}
 
-	if showCookies {
+	if !showCookies {
 		headerHiddenFields = append(headerHiddenFields, "cookie")
 	}
 

--- a/gindump_test.go
+++ b/gindump_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,15 +11,17 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 func init() {
 	gin.SetMode(gin.TestMode)
 }
 
-func performRequest(r http.Handler, method,contentType string ,path string,body io.Reader) *httptest.ResponseRecorder {
+func performRequest(r http.Handler, method, contentType string, path string, body io.Reader) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest(method, path, body)
-	req.Header.Set("Content-Type",contentType)
+	req.Header.Set("Content-Type", contentType)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	return w
@@ -34,29 +35,28 @@ func TestMIMEJSON(t *testing.T) {
 
 	router.POST("/dump", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
-			"ok":true,
-			"data":"gin-dump",
+			"ok":   true,
+			"data": "gin-dump",
 		})
 	})
 
-
 	type params struct {
 		StartTime string `json:"start_time"`
-		EndTime string `json:"end_time"`
+		EndTime   string `json:"end_time"`
 	}
 
 	var httpdata = params{
-		StartTime:"2019-03-03",
-		EndTime:"2019-03-03",
+		StartTime: "2019-03-03",
+		EndTime:   "2019-03-03",
 	}
-	b ,err := json.Marshal(httpdata)
+	b, err := json.Marshal(httpdata)
 	if err != nil {
 		fmt.Println("json format error:", err)
 		return
 	}
 
 	body := bytes.NewBuffer(b)
-	performRequest(router, "POST",gin.MIMEJSON ,"/dump",body)
+	performRequest(router, "POST", gin.MIMEJSON, "/dump", body)
 
 }
 
@@ -67,14 +67,14 @@ func TestMIMEPOSTFORM(t *testing.T) {
 	}))
 
 	router.POST("/dump", func(c *gin.Context) {
-		bts,err:=httputil.DumpRequest(c.Request,true)
-		fmt.Println(string(bts),err)
+		bts, err := httputil.DumpRequest(c.Request, true)
+		fmt.Println(string(bts), err)
 
 		c.JSON(http.StatusOK, gin.H{
-			"ok":true,
-			"data":map[string]interface{}{
-				"name":"jfise" ,
-				"addr":"tpkeeper@qq.com",
+			"ok": true,
+			"data": map[string]interface{}{
+				"name": "jfise",
+				"addr": "tpkeeper@qq.com",
 			},
 		})
 	})
@@ -84,8 +84,6 @@ func TestMIMEPOSTFORM(t *testing.T) {
 	form.Add("foo", "bar2")
 	form.Set("bar", "baz")
 
-
-	body:=strings.NewReader(form.Encode())
-	performRequest(router, "POST",gin.MIMEPOSTForm ,"/dump",body)
-
+	body := strings.NewReader(form.Encode())
+	performRequest(router, "POST", gin.MIMEPOSTForm, "/dump", body)
 }

--- a/parse.go
+++ b/parse.go
@@ -13,22 +13,31 @@ var StringMaxLength = 0
 var Newline = "\n"
 var Indent = 4
 
-func FormatJsonBytes(data []byte) ([]byte, error) {
+func FormatJsonBytes(data []byte, hiddenFields []string) ([]byte, error) {
 	var v interface{}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return nil, err
+	}
+
+	// case insensitive key deletion
+	for _, hiddenField := range hiddenFields {
+		for k, _ := range v.(map[string]interface{}) {
+			if strings.ToLower(k) == strings.ToLower(hiddenField) {
+				delete(v.(map[string]interface{}), k)
+			}
+		}
 	}
 
 	return []byte(format(v, 1)), nil
 }
 
 //support
-func FormatToJson(v interface{}) ([]byte, error) {
+func FormatToJson(v interface{}, hiddenFields []string) ([]byte, error) {
 	data, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
-	return FormatJsonBytes(data)
+	return FormatJsonBytes(data, hiddenFields)
 }
 
 func format(v interface{}, depth int) string {

--- a/parse.go
+++ b/parse.go
@@ -19,14 +19,7 @@ func FormatJsonBytes(data []byte, hiddenFields []string) ([]byte, error) {
 		return nil, err
 	}
 
-	// case insensitive key deletion
-	for _, hiddenField := range hiddenFields {
-		for k, _ := range v.(map[string]interface{}) {
-			if strings.ToLower(k) == strings.ToLower(hiddenField) {
-				delete(v.(map[string]interface{}), k)
-			}
-		}
-	}
+	v = removeHiddenFields(v, hiddenFields)
 
 	return []byte(format(v, 1)), nil
 }
@@ -126,4 +119,23 @@ func formatArray(a []interface{}, depth int) string {
 
 func generateIndent(depth int) string {
 	return strings.Repeat(" ", Indent*depth)
+}
+
+func removeHiddenFields(v interface{}, hiddenFields []string) interface{} {
+	if _, ok := v.(map[string]interface{}); !ok {
+		return v
+	}
+
+	m := v.(map[string]interface{})
+
+	// case insensitive key deletion
+	for _, hiddenField := range hiddenFields {
+		for k, _ := range m {
+			if strings.ToLower(k) == strings.ToLower(hiddenField) {
+				delete(m, k)
+			}
+		}
+	}
+
+	return m
 }


### PR DESCRIPTION
Adding a `DumpWithOptions` function for configurable output:

```golang
func DumpWithOptions(showReq bool, showResp bool, showBody bool, showHeaders bool, showCookies bool, cb func(dumpStr string)) gin.HandlerFunc
```

Back-compatible. :tada: